### PR TITLE
Reword ref to detailed instructions slightly

### DIFF
--- a/setup.qmd
+++ b/setup.qmd
@@ -50,7 +50,8 @@ bioinformatic software:
 2. having to build all packages from source
 
 You can find detailed instructions in [The Sandpaper Setup 
-Guide](https://carpentries.github.io/sandpaper-docs/#infrastructure-r-packages-2).
+Guide](https://carpentries.github.io/sandpaper-docs/#infrastructure-r-packages-2), 
+but the relevant commands are below.
 
 ### System Dependencies {-}
 


### PR DESCRIPTION
... to refer people to the quick specific instructions below instead of implying that they need to read the long instructions in the link.